### PR TITLE
Project flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,11 @@ project(Specter)
 
 option(BUILD_SPECPROJECT "Build SpecProject template" Off)
 
-set(SPECTER_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
-set(SPECTER_LIBRARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+if(NOT DEFINED SPECTER_BINARY_DIR)
+    set(SPECTER_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+elseif(NOT DEFINED SPECTER_LIBRARY_DIR) # optional block, can be repeated
+    set(SPECTER_LIBRARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
 
 add_subdirectory(Specter)
 if(BUILD_SPECPROJECT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ option(BUILD_SPECPROJECT "Build SpecProject template" Off)
 
 if(NOT DEFINED SPECTER_BINARY_DIR)
     set(SPECTER_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
-elseif(NOT DEFINED SPECTER_LIBRARY_DIR) # optional block, can be repeated
+endif()
+if(NOT DEFINED SPECTER_LIBRARY_DIR) # optional block, can be repeated
     set(SPECTER_LIBRARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 endif()
 


### PR DESCRIPTION
This is a small change the the CMakeLists.txt. Now when adding Specter as a subdirectory in a separate project file with it's own Specter binary/library directories defined it doesn't get changed. New project CMakeLists.txt located outside the Specter directory should have the following lines of code 

```cmake
set(SPECTER_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
set(SPECTER_LIBRARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Specter/lib)
```` 